### PR TITLE
I've made a fix to import the 'protect' middleware in `organizationRo…

### DIFF
--- a/backend/src/routes/organizationRoutes.js
+++ b/backend/src/routes/organizationRoutes.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcryptjs');
 const { getClient, query } = require('../db/db'); // Assuming db.js is in ../db/
 const { readSqlFile } = require('../utils/fileUtils');
 const path = require('path');
+const { protect } = require('../middleware/authMiddleware'); // <-- ADDED LINE
 
 const router = express.Router();
 


### PR DESCRIPTION
…utes`.

This resolves a `ReferenceError` where 'protect' was not defined.

The 'protect' authentication middleware was being used in `backend/src/routes/organizationRoutes.js` without being imported. I've added the necessary import statement: `const { protect } = require('../middleware/authMiddleware');` from `backend/src/middleware/authMiddleware.js` where it is defined and exported.