### PR TITLE
fix: Final corrections for 06_seed_basic_data.sql

### DIFF
--- a/backend/db_scripts/06_seed_basic_data.sql
+++ b/backend/db_scripts/06_seed_basic_data.sql
@@ -11,28 +11,32 @@ DECLARE
   schema_name TEXT := lower(regexp_replace(org_name, '[^a-zA-Z0-9_]+', '_', 'g'));
   user_email TEXT := 'testuser@example.com';
   -- Bcrypt hash for 'password123'.
-  -- This is a known example hash for 'password123': $2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy
   user_password_hash TEXT := '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy';
-  organization_id UUID;
+  organization_id INTEGER; -- Will hold the SERIAL ID from organizations table
 BEGIN
   -- 1. Create a sample organization and capture its ID
   -- Ensure schema_name is also inserted as it's a NOT NULL column.
   INSERT INTO public.organizations (name, schema_name)
   VALUES (org_name, schema_name)
-  ON CONFLICT (name) DO UPDATE SET schema_name = EXCLUDED.schema_name -- Or simply DO NOTHING if name collision means it's already set up
+  ON CONFLICT (name)
+  DO UPDATE SET schema_name = EXCLUDED.schema_name
   RETURNING id INTO organization_id;
 
-  -- If ON CONFLICT DO NOTHING and it conflicted, organization_id might be null.
-  -- Optionally, select it if it's null:
+  -- Fallback if the DO UPDATE did not execute due to no conflict, but we want to ensure organization_id is set
+  -- This is more relevant if DO NOTHING was used, but good for robustness.
   IF organization_id IS NULL THEN
-    SELECT id INTO organization_id FROM public.organizations WHERE name = org_name;
+    SELECT id INTO organization_id FROM public.organizations WHERE name = org_name AND schema_name = schema_name;
+  END IF;
+
+  -- Ensure organization_id is not null before proceeding
+  IF organization_id IS NULL THEN
+    RAISE EXCEPTION 'Failed to find or create organization: %', org_name;
   END IF;
 
   -- 2. Create a schema for the organization if it doesn't exist
   EXECUTE 'CREATE SCHEMA IF NOT EXISTS ' || quote_ident(schema_name);
 
   -- 3. Create the users table within the organization's schema
-  -- This structure is based on 03_create_users_table_template.sql
   EXECUTE 'CREATE TABLE IF NOT EXISTS ' || quote_ident(schema_name) || '.users (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       email VARCHAR(255) NOT NULL UNIQUE,
@@ -49,13 +53,18 @@ BEGIN
   EXECUTE 'INSERT INTO ' || quote_ident(schema_name) || '.users (email, password_hash, role) VALUES ($1, $2, $3) ON CONFLICT (email) DO NOTHING'
   USING user_email, user_password_hash, 'admin'; -- Assigning 'admin' role
 
-  RAISE NOTICE 'Successfully seeded data for organization: % (ID: %)', org_name, organization_id;
+  -- Using ::TEXT to be safe with NOTICE formatting for UUID
+  RAISE NOTICE 'Successfully seeded data for organization: % (ID: %)', org_name, organization_id::TEXT;
   RAISE NOTICE 'Created/Ensured schema: %', schema_name;
   RAISE NOTICE 'Created/Ensured user: % in schema %', user_email, schema_name;
 
 EXCEPTION
   WHEN OTHERS THEN
-    RAISE WARNING 'Error during seeding for organization %: %', org_name, SQLERRM;
+    -- Using ::TEXT for organization_id here too, if it was set.
+    RAISE WARNING 'Error during seeding for organization % (ID: %): %', org_name, organization_id::TEXT, SQLERRM;
     RAISE WARNING 'SQLSTATE: %', SQLSTATE;
+    -- Re-raise the exception to ensure the script fails if there's an issue
+    RAISE;
 END $$;
+-- End of script. Ensure no characters follow this line.
 ```


### PR DESCRIPTION
This commit addresses further issues in the database seeding script:

1.  **UUID/Integer Type Mismatch for `organization_id`**: The `public.organizations.id` column is `SERIAL` (integer), but the script variable `organization_id` was previously declared as `UUID`. This caused an "invalid input syntax for type uuid" error. The variable is now correctly declared as `INTEGER`.

2.  **Non-SQL Syntax Cleanup**: Ensured the script is entirely free of any lingering non-SQL syntax (like markdown backticks) that were causing parsing errors in `psql`.

3.  **Robustness**:
    - Added an explicit check to ensure `organization_id` is not null after attempting to insert/retrieve it, raising an exception if it is.
    - Ensured `RAISE NOTICE` and `RAISE WARNING` use `::TEXT` for the `organization_id` to prevent type issues in string formatting.
    - The main exception handler now re-raises exceptions to ensure the script properly fails on error.

This version should now execute correctly and robustly.