### PR TITLE
feat: Configure Vite proxy for frontend API requests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,12 @@ For a production environment, you might configure a `.env.production` file if Vi
     ```
     The application will usually be available at `http://localhost:5173` (Vite's default port, but check your terminal output). The server supports Hot Module Replacement (HMR).
 
+### API Proxy Configuration (Development)
+
+When running the frontend with `npm run dev`, the Vite development server is configured to proxy API requests. Any request made to a path starting with `/api` (e.g., `/api/auth/login`) will be automatically forwarded to the backend server, which is expected to be running at `http://localhost:3001`.
+
+This is configured in `vite.config.js`. If your backend server is running on a different port or address during development, you may need to update the `server.proxy.target` setting in `vite.config.js`.
+
 ## Building for Production
 
 1.  **Create a production build:**

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,17 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // string shorthand: '/foo' -> 'http://localhost:4567/foo'
+      // '/api': 'http://localhost:3001',
+      // Proxying /api to http://localhost:3001/api
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true, // Recommended for most cases, sets the host header to the target URL
+        // rewrite: (path) => path.replace(/^\/api/, ''), // Uncomment if your backend doesn't expect /api prefix
+      }
+    }
+  }
 })
+```


### PR DESCRIPTION
This commit introduces a server proxy configuration to the Vite development server for your frontend application.

Changes:
- I modified `frontend/vite.config.js` to include a `server.proxy` setting.
- API requests made from the frontend to paths starting with `/api` will now be proxied to `http://localhost:3001` (the assumed default backend port).
- This resolves issues where the frontend would make API calls to itself (e.g., `http://localhost:5173/api/...`) resulting in 404 errors.
- I updated `frontend/README.md` to document this proxy configuration for future developers.

This allows for seamless API integration during development when the frontend and backend servers are running on different ports.