### PR TITLE
fix: Attempt to resolve persistent full-width issue for Support/FAQ p…

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -16,6 +16,13 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 0;
+  padding-bottom: 0;
+  /* text-align: center; was removed from the other #root rule, so it remains removed */
+  /* max-width: 1280px; was removed from the other #root rule, so it remains removed */
+  /* margin: 0 auto; was removed from the other #root rule, so it remains removed */
 }
 
 /* General link styling */
@@ -67,16 +74,7 @@ button:hover, a.button-link:hover {
   box-shadow: 0 2px 5px rgba(0,0,0,0.05);
 }
 
-/* Existing Vite default styles below */
-#root {
-  /* max-width: 1280px; removed */
-  /* margin: 0 auto; removed */
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 0;
-  padding-bottom: 0;
-  /* text-align: center; removed */
-}
+/* Existing Vite default styles below - The #root rule here has been removed and merged above */
 
 .logo {
   height: 6em;

--- a/website/src/pages/FAQPage.tsx
+++ b/website/src/pages/FAQPage.tsx
@@ -6,6 +6,8 @@ const faqPageStyle: React.CSSProperties = {
   // maxWidth: '800px', // Removed to allow full width
   // margin: '0 auto', // Removed to allow full width
   fontFamily: 'Arial, sans-serif', // Keep font style
+  width: '100%', // Explicitly set width
+  boxSizing: 'border-box', // Ensure padding doesn't add to width
 };
 
 const faqItemStyle: React.CSSProperties = {

--- a/website/src/pages/SupportPage.tsx
+++ b/website/src/pages/SupportPage.tsx
@@ -5,6 +5,8 @@ const pageStyle: React.CSSProperties = {
   paddingTop: '20px', // Only vertical padding
   paddingBottom: '20px', // Only vertical padding
   lineHeight: '1.6',
+  width: '100%', // Explicitly set width
+  boxSizing: 'border-box', // Ensure padding doesn't add to width
 };
 
 const placeholderImageStyle: React.CSSProperties = {


### PR DESCRIPTION
…ages

This commit introduces further adjustments to ensure Support and FAQ pages utilize the full available width:

- Modified the root style objects (`pageStyle`, `faqPageStyle`) in `SupportPage.tsx` and `FAQPage.tsx` respectively to include `width: '100%'` and `box-sizing: 'border-box'`. This explicitly instructs these page components to fill their container.

- Consolidated duplicate `#root` styling rules in `App.css` into a single, comprehensive rule to ensure clarity and correct application of styles for the main application container, including flex properties for layout and padding for content spacing.