### PR TITLE
Remove "Discover LibrarySoft" heading from Slideshow

### DIFF
--- a/website/src/components/Slideshow.tsx
+++ b/website/src/components/Slideshow.tsx
@@ -20,7 +20,6 @@ const Slideshow: React.FC = () => {
   // For now, just static placeholders for slides
   return (
     <div style={slideshowStyle}>
-      <h2>Discover LibrarySoft</h2>
       <div style={slideStyle}>
         <h3>Slide 1: Welcome to the Future of Library Management</h3>
         <p>Placeholder text for the first slide. Describe a key benefit or feature.</p>


### PR DESCRIPTION
This commit removes the h2 heading "Discover LibrarySoft" from the Slideshow component on the homepage.