### PR TITLE
fix: Update button text in homepage 'LibrarySoft' section

### DIFF
--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -34,7 +34,7 @@ const HomePage: React.FC = () => {
             whiteSpace: 'nowrap', // Prevent button text from wrapping
           }}
         >
-          Go to LibrarySoft Product
+          LibrarySoft
         </a>
       </div>
       <ProductFeatures />


### PR DESCRIPTION
Changed the button text from "Go to LibrarySoft Product" to "LibrarySoft" as per your request.