### PR TITLE
Fix: Ensure Support and FAQ pages are full width

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -16,8 +16,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  padding-left: 30px;
-  padding-right: 30px;
   padding-top: 0;
   padding-bottom: 0;
   /* text-align: center; was removed from the other #root rule, so it remains removed */

--- a/website/src/pages/HomePage.tsx
+++ b/website/src/pages/HomePage.tsx
@@ -5,7 +5,7 @@ import PricingTable from '../components/PricingTable';
 
 const HomePage: React.FC = () => {
   return (
-    <div>
+    <div style={{ paddingLeft: '30px', paddingRight: '30px' }}>
       <Slideshow />
       <div style={{
         display: 'flex',


### PR DESCRIPTION
I removed global horizontal padding from the #root element in App.css. I added specific horizontal padding to HomePage.tsx to maintain its layout.

SupportPage.tsx and FAQPage.tsx were already styled with width: 100% and will now correctly display as full width as the parent #root container no longer constrains them with padding.