### PR TITLE
Refactor: Update pricing page layout and content

### DIFF
--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -11,7 +11,7 @@ const sectionStyle: React.CSSProperties = {
 
 const tierContainerStyle: React.CSSProperties = {
   display: 'flex',
-  justifyContent: 'space-around', // Distribute tiers evenly
+  justifyContent: 'center', // Distribute tiers evenly
   flexWrap: 'wrap', // Allow tiers to wrap on smaller screens
 };
 
@@ -20,7 +20,7 @@ const tierStyle: React.CSSProperties = {
   borderRadius: '8px',
   padding: '20px',
   margin: '10px',
-  width: '300px', // Fixed width for each tier
+  width: '350px', // Fixed width for each tier
   textAlign: 'center',
   backgroundColor: '#ffffff',
   boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
@@ -35,7 +35,7 @@ const tiers = [
   },
   {
     name: 'Pro Plan',
-    price: '₹1800/month', // Updated price
+    price: '$1000/month', // Updated price
     features: ['Up to 10,000 Books', 'Advanced Member Management', 'Reporting Tools', 'Email Support', 'Multiple Admin Users'],
     buttonText: 'Choose Pro',
   },
@@ -48,14 +48,20 @@ const PricingTable: React.FC = () => {
       <div style={tierContainerStyle}>
         {tiers.map((tier, index) => (
           <div key={index} style={tierStyle}>
-            <h3>{tier.name}</h3>
             <p style={{ fontSize: '1.5em', fontWeight: 'bold', margin: '10px 0' }}>{tier.price}</p>
             <ol style={{ listStyleType: 'decimal', paddingLeft: '40px', textAlign: 'left' }}>
               {tier.features.map((feature, fIndex) => (
                 <li key={fIndex} style={{ margin: '5px 0' }}>{feature}</li>
               ))}
             </ol>
-            <button style={{
+            <button style={tier.name === 'Free Plan' ? {
+              padding: '10px 20px',
+              marginTop: '20px',
+              backgroundColor: 'transparent',
+              color: 'transparent',
+              border: 'none',
+              cursor: 'default',
+            } : {
               padding: '10px 20px',
               marginTop: '20px',
               backgroundColor: '#5cb85c', // Green color for button


### PR DESCRIPTION
This commit implements the following changes to the pricing page:

- Removed "Free Plan" and "Pro Plan" headings from individual cards.
- Updated the "Pro Plan" price to $1000/month.
- Styled the button on the "Free Plan" card to be transparent and without a border, effectively removing its visual presence.
- Adjusted the card layout to utilize more horizontal space by centering the cards and increasing their width.

These changes address the issue of decluttering the pricing display and updating key information as per requirements.