### PR TITLE
Fix: Ensure Support and FAQ pages are truly full width

### DIFF
--- a/website/src/index.css
+++ b/website/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
The previous fix removed padding from #root, but the pages were still constrained because the `body` element in `index.css` had `display: flex; place-items: center;` which centered the #root element and prevented it from taking the full viewport width.

This commit removes these properties from the `body` style in `index.css`. This allows #root, and subsequently the main content area, to expand to the full viewport width.

SupportPage.tsx and FAQPage.tsx, with their existing `width: 100%` styles, will now correctly render as full-width pages. HomePage.tsx retains its own specific padding and is unaffected by this change to the body styling.