### PR TITLE
Fix: Correct currency for Pro Plan price

### DIFF
--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -35,7 +35,7 @@ const tiers = [
   },
   {
     name: 'Pro Plan',
-    price: '$1000/month', // Updated price
+    price: '₹1000/month', // Updated price
     features: ['Up to 10,000 Books', 'Advanced Member Management', 'Reporting Tools', 'Email Support', 'Multiple Admin Users'],
     buttonText: 'Choose Pro',
   },


### PR DESCRIPTION
This commit updates the Pro Plan price in the pricing table from $1000/month to ₹1000/month as per your feedback.