### PR TITLE
Style: Add consistent horizontal padding to Support and FAQ pages

### DIFF
--- a/website/src/pages/FAQPage.tsx
+++ b/website/src/pages/FAQPage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 const faqPageStyle: React.CSSProperties = {
-  paddingTop: '20px', // Only vertical padding
-  paddingBottom: '20px', // Only vertical padding
-  // maxWidth: '800px', // Removed to allow full width
-  // margin: '0 auto', // Removed to allow full width
-  fontFamily: 'Arial, sans-serif', // Keep font style
-  width: '100%', // Explicitly set width
-  boxSizing: 'border-box', // Ensure padding doesn't add to width
+  paddingTop: '20px',
+  paddingBottom: '20px',
+  paddingLeft: '30px', // Added padding
+  paddingRight: '30px', // Added padding
+  fontFamily: 'Arial, sans-serif',
+  width: '100%',
+  boxSizing: 'border-box',
 };
 
 const faqItemStyle: React.CSSProperties = {

--- a/website/src/pages/SupportPage.tsx
+++ b/website/src/pages/SupportPage.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 // Basic styling for the page elements
 const pageStyle: React.CSSProperties = {
-  paddingTop: '20px', // Only vertical padding
-  paddingBottom: '20px', // Only vertical padding
+  paddingTop: '20px',
+  paddingBottom: '20px',
+  paddingLeft: '30px', // Added padding
+  paddingRight: '30px', // Added padding
   lineHeight: '1.6',
-  width: '100%', // Explicitly set width
-  boxSizing: 'border-box', // Ensure padding doesn't add to width
+  width: '100%',
+  boxSizing: 'border-box',
 };
 
 const placeholderImageStyle: React.CSSProperties = {


### PR DESCRIPTION
Added 30px left and right padding to the main containers of SupportPage.tsx and FAQPage.tsx.

This makes their layout consistent with HomePage.tsx, using the available width with a standard margin from the viewport edges, as per your feedback.