### PR TITLE
Fix: Ensure Navbar active and hover styles apply correctly

### DIFF
--- a/website/src/components/Navbar.css
+++ b/website/src/components/Navbar.css
@@ -40,13 +40,13 @@
 }
 
 /* Hover state for navigation links */
-.nav-link:hover {
+.navbar .nav-link:hover {
   background-color: #555; /* Lighter grey on hover */
   color: white; /* Ensure text color remains white on hover */
 }
 
 /* Active state for navigation links */
-.nav-link.active {
+.navbar .nav-link.active {
   background-color: #007bff; /* Blue background for active link */
   color: white; /* Ensure text color remains white */
   font-weight: bold; /* Make active link text bold */


### PR DESCRIPTION
Global anchor tag styles in index.css and App.css were potentially interfering with the desired text color for active and hovered navigation links in the Navbar.

This commit increases the specificity of the CSS selectors in website/src/components/Navbar.css for .nav-link:hover and .nav-link.active by prefixing them with .navbar. This ensures that the Navbar's intended styles (white text, specific background colors) take precedence over the global styles.

The active link should now consistently show a blue background with white text, and hovered links should show a dark grey background with white text.