### PR TITLE
Fix: Remove trailing backticks from seed script

### DIFF
--- a/backend/db_scripts/06_seed_basic_data.sql
+++ b/backend/db_scripts/06_seed_basic_data.sql
@@ -67,4 +67,3 @@ EXCEPTION
     RAISE;
 END $$;
 -- End of script. Ensure no characters follow this line.
-```


### PR DESCRIPTION
The file `backend/db_scripts/06_seed_basic_data.sql` contained trailing backticks (```) that caused a syntax error when running the script. This commit removes these characters.