### PR TITLE
Refactor: Simplify environment configuration loading in db.js

### DIFF
--- a/backend/src/db/db.js
+++ b/backend/src/db/db.js
@@ -1,12 +1,6 @@
 const { Pool } = require('pg');
 require('dotenv').config(); // Load default .env file
-const path = require('path');
-
-// If NODE_ENV is 'test', load .env.test variables, potentially overriding some from .env
-if (process.env.NODE_ENV === 'test') {
-  require('dotenv').config({ path: path.resolve(process.cwd(), '.env.test'), override: true });
-  console.log('Running in test mode, loaded .env.test');
-}
+// const path = require('path'); // No longer needed as .env.test loading is removed
 
 const dbConfig = {
   user: process.env.PGUSER,
@@ -16,7 +10,7 @@ const dbConfig = {
   port: process.env.PGPORT,
 };
 
-// Log database being used, especially for test environment
+// Log database being used
 console.log(`Connecting to database: ${dbConfig.database} on host ${dbConfig.host}`);
 
 const pool = new Pool(dbConfig);
@@ -27,14 +21,11 @@ pool.on('connect', () => {
 
 pool.on('error', (err) => {
   console.error('Unexpected error on idle client', err);
-  // In a real app, you might want to handle this more gracefully than exiting
-  // For tests, exiting might be fine if the DB connection is critical.
   process.exit(-1);
 });
 
 module.exports = {
   query: (text, params) => pool.query(text, params),
   getClient: () => pool.connect(),
-  pool, // Exporting pool directly for more complex operations like transactions if needed outside
-  // And potentially for test cleanup utilities
+  pool,
 };


### PR DESCRIPTION
I modified `backend/src/db/db.js` to remove the conditional logic that loaded `.env.test` when `NODE_ENV` was set to 'test'. The database connection configuration will now consistently rely on the values present in the default `.env` file (or actual environment variables if set).

This change simplifies the configuration process and makes it easier for you to trace the source of database connection parameters, aiding in diagnosing connection-related issues. The `path` module import was also commented out as it was no longer used after this change.