### PR TITLE
Fix: Trim whitespace from password in login route

### DIFF
--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -71,8 +71,9 @@ router.post('/login', async (req, res) => {
     const user = userResult.rows[0];
     console.log(`[LOGIN INFO] Found user: Email='${user.email}', ID='${user.id}'`);
 
-    console.log(`[LOGIN AUTH] Comparing password for user '${user.email}'. Provided password length: ${password.length}, Stored hash: '${user.password_hash}'`);
-    const isPasswordMatch = await bcrypt.compare(password, user.password_hash);
+    const trimmedPassword = password.trim();
+    console.log(`[LOGIN AUTH] Comparing password for user '${user.email}'. Provided (after trim) password length: ${trimmedPassword.length}, Stored hash: '${user.password_hash}'`);
+    const isPasswordMatch = await bcrypt.compare(trimmedPassword, user.password_hash);
     console.log(`[LOGIN AUTH] Password comparison result: ${isPasswordMatch}`);
 
     if (!isPasswordMatch) {


### PR DESCRIPTION
I modified the POST /api/auth/login route in `backend/src/routes/authRoutes.js` to trim leading/trailing whitespace from the password received in the request body before performing the `bcrypt.compare` operation.

This fixes an issue where `bcrypt.compare()` would return `false` if the provided password string contained extraneous whitespace (e.g., "password123 ") even if the core password was correct, leading to login failures. The diagnostic logging for password length was also updated to reflect the length of the trimmed password.